### PR TITLE
Puppet.newtype is deprecated

### DIFF
--- a/lib/puppet/type/git_deploy_key.rb
+++ b/lib/puppet/type/git_deploy_key.rb
@@ -1,5 +1,5 @@
 module Puppet
-  newtype(:git_deploy_key) do
+  Puppet::Type.newtype(:git_deploy_key) do
 
     @doc = %q{A deploy key is an SSH key that is stored on your server and grants access to a single GitHub repository.  This key is attached directly to the repository instead of to a personal user account.  Anyone with access to the repository and server has the ability to deploy the project.  It is also beneficial for users since they are not required to change their local SSH settings.
     }


### PR DESCRIPTION
Prior to this, the git_deploy_key type was created using the
`Puppet.newtype` function. That has been deprecated and shows as a
warning on Puppet versions higher than 4. This creates the
git_deploy_key type by calling the `Puppet::Type.newtype()` function,
which is not deprecated.

Fixes issue #11 