### PR TITLE
Add support for disable_ssl_verify in the gitlab webhook provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,14 +287,16 @@ The name of the repository associated
 repo_name       => 'control',
 ```
 
-### GitHub optional parameters
+### GitHub & Gitlab optional parameters
 
 #### disable\_ssl_verify
-Boolean value for disabling SSL verification for this webhook. **NOTE: GitHub only**
+Boolean value for disabling SSL verification for this webhook. **NOTE: Does not work on Stash **
 
 ```puppet
 disable_ssl_verify => true,
 ```
+
+The gitlab provider sets `enable_ssl_verification` to false when this attribute is used
 
 ### GitLab optional Parameters
 

--- a/lib/puppet/provider/git_webhook/gitlab.rb
+++ b/lib/puppet/provider/git_webhook/gitlab.rb
@@ -141,6 +141,14 @@ Puppet::Type.type(:git_webhook).provide(:gitlab) do
     begin
       opts = { 'url' => resource[:webhook_url].strip }
       
+      if resource.disable_ssl_verify?
+        if resource[:disable_ssl_verify] == true
+          opts['enable_ssl_verification'] = 'false'
+        else
+          opts['enable_ssl_verification'] = 'true'
+        end
+      end
+
       if resource.merge_request_events?
         opts['merge_requests_events'] = resource[:merge_request_events]
       end


### PR DESCRIPTION
This utilizes the enable_ssl_verification paramter in the Gitlab
API.

http://doc.gitlab.com/ce/api/projects.html#list-project-hooks