### PR TITLE
Support SSL on ports other than 443

### DIFF
--- a/lib/puppet/parser/functions/gitlab_add_deploy_key.rb
+++ b/lib/puppet/parser/functions/gitlab_add_deploy_key.rb
@@ -17,7 +17,7 @@ module Puppet::Parser::Functions
     uri = URI.parse("https://gitlab.com/api/v3/projects/#{project_id}/keys")
     http = Net::HTTP.new(uri.host, uri.port)
 
-    if uri.port = 443
+    if uri.port = 443 or uri.scheme == 'https'
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     end

--- a/lib/puppet/parser/functions/gitlab_add_user_to_project.rb
+++ b/lib/puppet/parser/functions/gitlab_add_user_to_project.rb
@@ -22,7 +22,7 @@ module Puppet::Parser::Functions
     uri = URI.parse("https://gitlab.com/api/v3/projects/#{project_id}/members")
     http = Net::HTTP.new(uri.host, uri.port)
 
-    if uri.port = 443
+    if uri.port = 443 or uri.scheme == 'https'
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     end

--- a/lib/puppet/parser/functions/gitlab_projects.rb
+++ b/lib/puppet/parser/functions/gitlab_projects.rb
@@ -25,7 +25,7 @@ module Puppet::Parser::Functions
 
     http = Net::HTTP.new(uri.host, uri.port)
 
-    if uri.port = 443
+    if uri.port = 443 or uri.scheme == 'https'
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     end

--- a/lib/puppet/provider/git_deploy_key/github.rb
+++ b/lib/puppet/provider/git_deploy_key/github.rb
@@ -26,7 +26,7 @@ Puppet::Type.type(:git_deploy_key).provide(:github) do
 
     http = Net::HTTP.new(uri.host, uri.port)
 
-    if uri.port == 443
+    if uri.port == 443 or uri.scheme == 'https'
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     else

--- a/lib/puppet/provider/git_deploy_key/gitlab.rb
+++ b/lib/puppet/provider/git_deploy_key/gitlab.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:git_deploy_key).provide(:gitlab) do
 
     http = Net::HTTP.new(uri.host, uri.port)
 
-    if uri.port == 443
+    if uri.port == 443 or uri.scheme == 'https'
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     else

--- a/lib/puppet/provider/git_deploy_key/stash.rb
+++ b/lib/puppet/provider/git_deploy_key/stash.rb
@@ -54,7 +54,7 @@ Puppet::Type.type(:git_deploy_key).provide(:stash) do
 
     http = Net::HTTP.new(uri.host, uri.port)
 
-    if uri.port == 443
+    if uri.port == 443 or uri.scheme == 'https'
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     else

--- a/lib/puppet/provider/git_groupteam/gitlab.rb
+++ b/lib/puppet/provider/git_groupteam/gitlab.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:git_groupteam).provide(:gitlab) do
 
     http = Net::HTTP.new(uri.host, uri.port)
 
-    if uri.port == 443
+    if uri.port == 443 or uri.scheme == 'https'
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     else

--- a/lib/puppet/provider/git_groupteam_member/gitlab.rb
+++ b/lib/puppet/provider/git_groupteam_member/gitlab.rb
@@ -31,7 +31,7 @@ Puppet::Type.type(:git_groupteam_member).provide(:gitlab) do
 
     http = Net::HTTP.new(uri.host, uri.port)
 
-    if uri.port == 443
+    if uri.port == 443 or uri.scheme == 'https'
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     else

--- a/lib/puppet/provider/git_webhook/github.rb
+++ b/lib/puppet/provider/git_webhook/github.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:git_webhook).provide(:github) do
 
     http = Net::HTTP.new(uri.host, uri.port)
 
-    if uri.port == 443
+    if uri.port == 443 or uri.scheme == 'https'
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     else

--- a/lib/puppet/provider/git_webhook/gitlab.rb
+++ b/lib/puppet/provider/git_webhook/gitlab.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:git_webhook).provide(:gitlab) do
 
     http = Net::HTTP.new(uri.host, uri.port)
 
-    if uri.port == 443
+    if uri.port == 443 or uri.scheme == 'https'
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     else

--- a/lib/puppet/provider/git_webhook/stash.rb
+++ b/lib/puppet/provider/git_webhook/stash.rb
@@ -57,7 +57,7 @@ Puppet::Type.type(:git_webhook).provide(:stash) do
 
     http = Net::HTTP.new(uri.host, uri.port)
 
-    if uri.port == 443
+    if uri.port == 443 or uri.scheme == 'https'
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     else


### PR DESCRIPTION
added check for uri.scheme to determine if we should use ssl to connect to the remote server_url