### PR TITLE
Token file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ This is the unique token you created within your GMS to allow you to interface w
 token        => 'ABCDEF1234568',
 ```
 
+#### token\_file
+The path to a file containing the unique token you created within your GMS to allow you to interface with the system via the API. This is an alternative to, and is mutually exlusive to use of the `token` parameter.
+
+```puppet
+token_file   => '/etc/gitlab/api-token',
+```
+
 ### Stash mandatory authentication parameters
 
 Stash utilizes a Basic Authentication system as well as an OAuth system for accessing their API respectively.  Since OAuth requires a callback URL based system that can not be feasibly implemented by this GMS module, only Basic Authenticaiton is supported.
@@ -178,7 +185,7 @@ git_deploy_key { 'magical stash deploy key' :
 
 --
 
-## git_webhook
+## git\_webhook
 
 A webhook allows repository admins to manage the post-receive hooks for a repository.  Very helpful in the case you have many Puppet masters you manage and therefore are responsible for their respective webhooks.  This is refers only to respository webhooks and not organizational webhook as offered by Github.  If that functionality is ever supported by this project it will be identified separately.
 
@@ -220,7 +227,7 @@ or
 provider     => 'stash',
 ```
 
-#### webhook_url
+#### webhook\_url
 
 The URL relating to the webhook.  This typically has payload in the name.
 
@@ -235,7 +242,14 @@ This is the unique token you created within your GMS to allow you to interface w
 token        => 'ABCDEF1234568',
 ```
 
-#### project_name
+#### token\_file
+The path to a file containing the unique token you created within your GMS to allow you to interface with the system via the API. This is an alternative to, and is mutually exlusive to use of the `token` parameter.
+
+```puppet
+token_file   => '/etc/gitlab/api-token',
+```
+
+#### project\_name
 The project name associated with the project
 
 Be sure to follow the 'userid/repo' format to insure proper operation for GitHub & GitLab.  For Stash, only include the project name for this parameter.
@@ -244,7 +258,7 @@ Be sure to follow the 'userid/repo' format to insure proper operation for GitHub
 project_name => 'control',
 ```
 
-#### server_url
+#### server\_url
 The URL path to the Git management system server
 
 Both http & https URLs are acceptable.
@@ -262,6 +276,13 @@ This is the unique token you created within your GMS to allow you to interface w
 
 ```puppet
 token        => 'ABCDEF1234568',
+```
+
+#### token\_file
+The path to a file containing the unique token you created within your GMS to allow you to interface with the system via the API. This is an alternative to, and is mutually exlusive to use of the `token` parameter.
+
+```puppet
+token_file   => '/etc/gitlab/api-token',
 ```
 
 ### Stash mandatory authentication parameters
@@ -296,7 +317,7 @@ repo_name       => 'control',
 
 ### GitHub & Gitlab optional parameters
 
-#### disable\_ssl_verify
+#### disable\_ssl\_verify
 Boolean value for disabling SSL verification for this webhook. **NOTE: Does not work on Stash **
 
 ```puppet
@@ -307,7 +328,7 @@ The gitlab provider sets `enable_ssl_verification` to false when this attribute 
 
 ### GitLab optional Parameters
 
-#### merge\_request_events
+#### merge\_request\_events
 The URL in the webhook_url parameter will be triggered when a merge requests event occurs. **NOTE: GitLab only**
 
 ```puppet

--- a/lib/puppet/provider/git_deploy_key/github.rb
+++ b/lib/puppet/provider/git_deploy_key/github.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:git_deploy_key).provide(:github) do
     return resource[:server_url].strip unless resource[:server_url].nil?
     return 'https://api.github.com'
   end
-  
+
   def calling_method
     # Get calling method and clean it up for good reporting
     cm = String.new
@@ -60,9 +60,9 @@ Puppet::Type.type(:git_deploy_key).provide(:github) do
     Puppet.debug("github_deploy_key::#{calling_method}: REST API #{req.method} Request: #{req.inspect}")
 
     response = http.request(req)
-    
+
     Puppet.debug("github_deploy_key::#{calling_method}: REST API #{req.method} Response: #{response.inspect}")
-    
+
     response
   end
 
@@ -73,7 +73,7 @@ Puppet::Type.type(:git_deploy_key).provide(:github) do
     response = api_call('GET', url)
 
     key_json = JSON.parse(response.body)
-    
+
     key_json.each do |child|
       if child['key'].split(" ")[1].eql?(File.read(resource[:path].strip).split(" ")[1])
         return true
@@ -82,7 +82,7 @@ Puppet::Type.type(:git_deploy_key).provide(:github) do
 
     return false
   end
-  
+
   def get_key_id
     key_hash = Hash.new
     url = "#{gms_server}/repos/#{resource[:project_name].strip}/keys"
@@ -90,7 +90,7 @@ Puppet::Type.type(:git_deploy_key).provide(:github) do
     response = api_call('GET', url)
 
     key_json = JSON.parse(response.body)
-    
+
     key_json.each do |child|
       if child['key'].split(" ")[1].eql?(File.read(resource[:path].strip).split(" ")[1])
         return child['id'].to_s
@@ -119,7 +119,7 @@ Puppet::Type.type(:git_deploy_key).provide(:github) do
 
   def destroy
     key_id = get_key_id
-    
+
     unless key_id.nil?
       url = "#{gms_server}/repos/#{resource[:project_name].strip}/keys/#{key_id}"
 

--- a/lib/puppet/provider/git_deploy_key/github.rb
+++ b/lib/puppet/provider/git_deploy_key/github.rb
@@ -1,8 +1,10 @@
 require 'puppet'
 require 'net/http'
 require 'json'
+require 'puppet_x/gms/provider'
 
 Puppet::Type.type(:git_deploy_key).provide(:github) do
+  include PuppetX::GMS::Provider
 
   defaultfor :github => :exist
   defaultfor :feature => :posix
@@ -49,8 +51,8 @@ Puppet::Type.type(:git_deploy_key).provide(:github) do
 
     req.initialize_http_header({'Accept' => 'application/vnd.github.v3+json', 'User-Agent' => 'puppet-gms'})
     req.set_content_type('application/json')
-    req.add_field('Authorization', "token #{resource[:token].strip}")
-    #req.add_field('PRIVATE-TOKEN', resource[:token])
+    req.add_field('Authorization', "token #{get_token}")
+    #req.add_field('PRIVATE-TOKEN', get_token)
 
     if data
       req.body = data.to_json

--- a/lib/puppet/provider/git_deploy_key/gitlab.rb
+++ b/lib/puppet/provider/git_deploy_key/gitlab.rb
@@ -10,7 +10,7 @@ Puppet::Type.type(:git_deploy_key).provide(:gitlab) do
     return resource[:server_url].strip unless resource[:server_url].nil?
     return 'https://gitlab.com'
   end
-  
+
   def calling_method
     # Get calling method and clean it up for good reporting
     cm = String.new
@@ -57,9 +57,9 @@ Puppet::Type.type(:git_deploy_key).provide(:gitlab) do
     Puppet.debug("gitlab_deploy_key::#{calling_method}: REST API #{req.method} Request: #{req.inspect}")
 
     response = http.request(req)
-    
+
     Puppet.debug("gitlab_deploy_key::#{calling_method}: REST API #{req.method} Response: #{response.inspect}")
-    
+
     response
   end
 
@@ -100,7 +100,7 @@ Puppet::Type.type(:git_deploy_key).provide(:gitlab) do
 
     begin
       response = api_call('GET', url)
-      return JSON.parse(response.body)['id'].to_i 
+      return JSON.parse(response.body)['id'].to_i
     rescue Exception => e
       fail(Puppet::Error, "gitlab_deploy_key::#{calling_method}: #{e.message}")
       return nil
@@ -132,7 +132,7 @@ Puppet::Type.type(:git_deploy_key).provide(:gitlab) do
     raise(Puppet::Error, "gitlab_deploy_key::#{calling_method}: Unable to find nonexistent project ID \'#{resource[:project_name].strip}\' to retrieve corresponding key ID")
     return nil
   end
-    
+
   def create
     project_id = get_project_id
 

--- a/lib/puppet/provider/git_deploy_key/gitlab.rb
+++ b/lib/puppet/provider/git_deploy_key/gitlab.rb
@@ -1,8 +1,10 @@
 require 'puppet'
 require 'net/http'
 require 'json'
+require 'puppet_x/gms/provider'
 
 Puppet::Type.type(:git_deploy_key).provide(:gitlab) do
+  include PuppetX::GMS::Provider
 
   defaultfor :gitlab => :exists
 
@@ -47,7 +49,7 @@ Puppet::Type.type(:git_deploy_key).provide(:gitlab) do
     end
 
     req.set_content_type('application/json')
-    req.add_field('PRIVATE-TOKEN', resource[:token])
+    req.add_field('PRIVATE-TOKEN', get_token)
 
     if data
       req.body = data.to_json

--- a/lib/puppet/provider/git_groupteam/gitlab.rb
+++ b/lib/puppet/provider/git_groupteam/gitlab.rb
@@ -1,8 +1,10 @@
 require 'puppet'
 require 'net/http'
 require 'json'
+require 'puppet_x/gms/provider'
 
 Puppet::Type.type(:git_groupteam).provide(:gitlab) do
+  include PuppetX::GMS::Provider
 
   defaultfor :gitlab => :exists
 
@@ -47,7 +49,7 @@ Puppet::Type.type(:git_groupteam).provide(:gitlab) do
     end
 
     req.set_content_type('application/json')
-    req.add_field('PRIVATE-TOKEN', resource[:token])
+    req.add_field('PRIVATE-TOKEN', get_token)
 
     if data
       req.body = data.to_json

--- a/lib/puppet/provider/git_groupteam/gitlab.rb
+++ b/lib/puppet/provider/git_groupteam/gitlab.rb
@@ -10,7 +10,7 @@ Puppet::Type.type(:git_groupteam).provide(:gitlab) do
     return resource[:server_url].strip unless resource[:server_url].nil?
     return 'https://gitlab.com'
   end
-  
+
   def calling_method
     # Get calling method and clean it up for good reporting
     cm = String.new
@@ -57,9 +57,9 @@ Puppet::Type.type(:git_groupteam).provide(:gitlab) do
     Puppet.debug("gitlab_groupteam::#{calling_method}: REST API #{req.method} Request: #{req.inspect}")
 
     response = http.request(req)
-    
+
     Puppet.debug("gitlab_groupteam::#{calling_method}: REST API #{req.method} Response: #{response.inspect}")
-    
+
     response
   end
 
@@ -70,11 +70,11 @@ Puppet::Type.type(:git_groupteam).provide(:gitlab) do
     response = api_call('GET', url)
 
     groupteam_json = JSON.parse(response.body)
-    
+
     groupteam_json.each do |child|
       groupteam_hash[child['name']] = child['description']
     end
-    
+
     groupteam_hash.each do |k,v|
       if k.eql?(resource[:groupteam_name].strip)
         unless (v.nil? && resource[:description].nil?) || (v && resource[:description]) && v.eql?(resource[:description].strip)
@@ -90,7 +90,7 @@ Puppet::Type.type(:git_groupteam).provide(:gitlab) do
     Puppet.debug "gitlab_groupteam::#{calling_method}: Group \'#{resource[:name]}\' does not currently exist"
     return false
   end
-  
+
   def get_group_id
     group_hash = Hash.new
 
@@ -109,21 +109,21 @@ Puppet::Type.type(:git_groupteam).provide(:gitlab) do
         return v.to_i
       end
     end
-    
+
     raise(Puppet::Error, "gitlab_groupteam_member::#{calling_method}: Unable to find nonexistent group \'#{resource[:groupteam_name].strip}\'")
     return nil
   end
-    
+
   def create
     url = "#{gms_server}/api/v3/groups"
 
     begin
       opts = { 'name' => resource[:groupteam_name].strip, 'path' => resource[:groupteam_name].strip }
-      
+
       unless resource[:description].nil?
         opts['description'] = resource[:description].strip
       end
-      
+
       Puppet.debug("opts => #{opts.inspect}")
 
       response = api_call('POST', url, opts)

--- a/lib/puppet/provider/git_groupteam_member/gitlab.rb
+++ b/lib/puppet/provider/git_groupteam_member/gitlab.rb
@@ -1,8 +1,10 @@
 require 'puppet'
 require 'net/http'
 require 'json'
+require 'puppet_x/gms/provider'
 
 Puppet::Type.type(:git_groupteam_member).provide(:gitlab) do
+  include PuppetX::GMS::Provider
 
   defaultfor :gitlab => :exists
 
@@ -54,7 +56,7 @@ Puppet::Type.type(:git_groupteam_member).provide(:gitlab) do
     end
 
     req.set_content_type('application/json')
-    req.add_field('PRIVATE-TOKEN', resource[:token])
+    req.add_field('PRIVATE-TOKEN', get_token)
 
     if data
       req.body = data.to_json

--- a/lib/puppet/provider/git_groupteam_member/gitlab.rb
+++ b/lib/puppet/provider/git_groupteam_member/gitlab.rb
@@ -5,7 +5,7 @@ require 'json'
 Puppet::Type.type(:git_groupteam_member).provide(:gitlab) do
 
   defaultfor :gitlab => :exists
-  
+
   GUEST     = 10
   REPORTER  = 20
   DEVELOPER = 30
@@ -16,7 +16,7 @@ Puppet::Type.type(:git_groupteam_member).provide(:gitlab) do
     return resource[:server_url].strip unless resource[:server_url].nil?
     return 'https://gitlab.com'
   end
-  
+
   def calling_method
     # Get calling method and clean it up for good reporting
     cm = String.new
@@ -64,15 +64,15 @@ Puppet::Type.type(:git_groupteam_member).provide(:gitlab) do
     Puppet.debug("gitlab_groupteam_member::#{calling_method}: REST API #{req.method} Request: #{req.inspect}")
 
     response = http.request(req)
-    
+
     Puppet.debug("gitlab_groupteam_member::#{calling_method}: REST API #{req.method} Response: #{response.inspect}")
-    
+
     response
   end
 
   def exists?
     group_id = get_group_id
-    
+
     groupteam_hash = Hash.new
     url = "#{gms_server}/api/v3//groups/#{group_id}/members"
 
@@ -94,11 +94,11 @@ Puppet::Type.type(:git_groupteam_member).provide(:gitlab) do
     Puppet.debug "gitlab_groupteam_member::#{calling_method}: Member \'#{resource[:member_name]}\' is not currently a member of #{resource[:groupteam_name].strip}"
     return false
   end
-  
-  def get_access_level    
+
+  def get_access_level
     unless resource[:access_level].nil?
       al = resource[:access_level].strip
-      
+
       case al
       when /guest/i
         Puppet.debug("gitlab_groupteam_member::#{calling_method}:  Access Level = #{GUEST}")
@@ -124,7 +124,7 @@ Puppet::Type.type(:git_groupteam_member).provide(:gitlab) do
       return nil
     end
   end
-  
+
   def get_group_id
     group_hash = Hash.new
 
@@ -147,7 +147,7 @@ Puppet::Type.type(:git_groupteam_member).provide(:gitlab) do
     raise(Puppet::Error, "gitlab_groupteam_member::#{calling_method}: Unable to find nonexistent group \'#{resource[:groupteam_name].strip}\'")
     return nil
   end
-  
+
   def get_user_id
     group_hash = Hash.new
 
@@ -156,7 +156,7 @@ Puppet::Type.type(:git_groupteam_member).provide(:gitlab) do
     response = api_call('GET', url)
 
     group_json = JSON.parse(response.body)
-    
+
     group_json.each do |child|
       group_hash[child['username']] = child['id']
     end
@@ -170,12 +170,12 @@ Puppet::Type.type(:git_groupteam_member).provide(:gitlab) do
     raise(Puppet::Error, "gitlab_groupteam_member::#{calling_method}: Unable to add nonexistent user \'#{resource[:member_name].strip}\' to group #{resource[:groupteam_name].strip}")
     return nil
   end
-    
+
   def create
     access_level = get_access_level
     group_id = get_group_id
     user_id  = get_user_id
-    
+
     url = "#{gms_server}/api/v3//groups/#{group_id}/members"
 
     begin

--- a/lib/puppet/provider/git_webhook/github.rb
+++ b/lib/puppet/provider/git_webhook/github.rb
@@ -1,8 +1,10 @@
 require 'puppet'
 require 'net/http'
 require 'json'
+require 'puppet_x/gms/provider'
 
 Puppet::Type.type(:git_webhook).provide(:github) do
+  extend PuppetX::GMS::Provider
 
   defaultfor :github => :exist
   defaultfor :feature => :posix
@@ -51,7 +53,7 @@ Puppet::Type.type(:git_webhook).provide(:github) do
 
     req.initialize_http_header({'Accept' => 'application/vnd.github.v3+json', 'User-Agent' => 'puppet-gms'})
     req.set_content_type('application/json')
-    req.add_field('Authorization', "token #{resource[:token].strip}")
+    req.add_field('Authorization', "token #{get_token}")
 
     if data
       req.body = data.to_json

--- a/lib/puppet/provider/git_webhook/github.rb
+++ b/lib/puppet/provider/git_webhook/github.rb
@@ -3,7 +3,7 @@ require 'net/http'
 require 'json'
 
 Puppet::Type.type(:git_webhook).provide(:github) do
-  
+
   defaultfor :github => :exist
   defaultfor :feature => :posix
 
@@ -12,7 +12,7 @@ Puppet::Type.type(:git_webhook).provide(:github) do
     return resource[:server_url].strip unless resource[:server_url].nil?
     return 'https://api.github.com'
   end
-  
+
   def calling_method
     # Get calling method and clean it up for good reporting
     cm = String.new
@@ -61,9 +61,9 @@ Puppet::Type.type(:git_webhook).provide(:github) do
     Puppet.debug("github_webhook::#{calling_method}: REST API #{req.method} Request: #{req.inspect}")
 
     response = http.request(req)
-    
+
     Puppet.debug("github_webhook::#{calling_method}: REST API #{req.method} Response: #{response.inspect}")
-    
+
     response
   end
 
@@ -84,7 +84,7 @@ Puppet::Type.type(:git_webhook).provide(:github) do
         return true
       end
     end
-    
+
     Puppet.debug "github_webhook::#{calling_method}: Webhook does not currently exist as specified in calling resource block."
     return false
   end
@@ -102,7 +102,7 @@ Puppet::Type.type(:git_webhook).provide(:github) do
 
     begin
       response = api_call('GET', url)
-      return JSON.parse(response.body)['id'].to_i 
+      return JSON.parse(response.body)['id'].to_i
     rescue Exception => e
       fail(Puppet::Error, "github_webhook::#{calling_method}: #{e.backtrace}")
       return nil
@@ -131,13 +131,13 @@ Puppet::Type.type(:git_webhook).provide(:github) do
 
     return nil
   end
-    
+
   def create
     url = "#{gms_server}/repos/#{resource[:project_name].strip}/hooks"
 
     begin
       config_opts = { 'url' => resource[:webhook_url].strip, 'content_type' => 'json' }
-      
+
       if resource.disable_ssl_verify?
         if resource[:disable_ssl_verify] == true
           config_opts['insecure_ssl'] = 1
@@ -145,7 +145,7 @@ Puppet::Type.type(:git_webhook).provide(:github) do
           config_opts['insecure_ssl'] = 0
         end
       end
-      
+
       response = api_call('POST', url, { 'name' => 'web', 'active' => true, 'config' => config_opts })
 
       if response.class == Net::HTTPCreated

--- a/lib/puppet/provider/git_webhook/gitlab.rb
+++ b/lib/puppet/provider/git_webhook/gitlab.rb
@@ -10,7 +10,7 @@ Puppet::Type.type(:git_webhook).provide(:gitlab) do
     return resource[:server_url].strip unless resource[:server_url].nil?
     return 'https://gitlab.com'
   end
-  
+
   def calling_method
     # Get calling method and clean it up for good reporting
     cm = String.new
@@ -57,9 +57,9 @@ Puppet::Type.type(:git_webhook).provide(:gitlab) do
     Puppet.debug("gitlab_webhook::#{calling_method}: REST API #{req.method} Request: #{req.inspect}")
 
     response = http.request(req)
-    
+
     Puppet.debug("gitlab_webhook::#{calling_method}: REST API #{req.method} Response: #{response.inspect}")
-    
+
     response
   end
 
@@ -72,7 +72,7 @@ Puppet::Type.type(:git_webhook).provide(:gitlab) do
     response = api_call('GET', url)
 
     webhook_json = JSON.parse(response.body)
-    
+
     webhook_json.each do |child|
       webhook_hash[child['url']] = child['id']
     end
@@ -101,7 +101,7 @@ Puppet::Type.type(:git_webhook).provide(:gitlab) do
 
     begin
       response = api_call('GET', url)
-      return JSON.parse(response.body)['id'].to_i 
+      return JSON.parse(response.body)['id'].to_i
     rescue Exception => e
       fail(Puppet::Error, "gitlab_webhook::#{calling_method}: #{e.message}")
       return nil
@@ -132,15 +132,15 @@ Puppet::Type.type(:git_webhook).provide(:gitlab) do
 
     return nil
   end
-    
+
   def create
     project_id = get_project_id
 
     url = "#{gms_server}/api/v3/projects/#{project_id}/hooks"
-    
+
     begin
       opts = { 'url' => resource[:webhook_url].strip }
-      
+
       if resource.disable_ssl_verify?
         if resource[:disable_ssl_verify] == true
           opts['enable_ssl_verification'] = 'false'
@@ -156,11 +156,11 @@ Puppet::Type.type(:git_webhook).provide(:gitlab) do
       if resource.tag_push_events?
         opts['tag_push_events'] = resource[:tag_push_events]
       end
-      
+
       if resource.issue_events?
         opts['issues_events'] = resource[:issue_events]
       end
-      
+
       response = api_call('POST', url, opts)
 
       if (response.class == Net::HTTPCreated)

--- a/lib/puppet/provider/git_webhook/gitlab.rb
+++ b/lib/puppet/provider/git_webhook/gitlab.rb
@@ -1,8 +1,10 @@
 require 'puppet'
 require 'net/http'
 require 'json'
+require 'puppet_x/gms/provider'
 
 Puppet::Type.type(:git_webhook).provide(:gitlab) do
+  include PuppetX::GMS::Provider
 
   defaultfor :gitlab => :exists
 
@@ -47,7 +49,7 @@ Puppet::Type.type(:git_webhook).provide(:gitlab) do
     end
 
     req.set_content_type('application/json')
-    req.add_field('PRIVATE-TOKEN', resource[:token])
+    req.add_field('PRIVATE-TOKEN', get_token)
 
     if data
       req.body = data.to_json

--- a/lib/puppet/type/git_deploy_key.rb
+++ b/lib/puppet/type/git_deploy_key.rb
@@ -28,14 +28,14 @@ module Puppet
         String(value)
       end
     end
-    
+
     newparam(:username) do
       desc 'The username to be used to authenticate with the Stash server for API access.'
       munge do |value|
         String(value)
       end
     end
-    
+
     newparam(:password) do
       desc 'The password to be used to authenticate with the Stash server for API access.'
       munge do |value|
@@ -56,7 +56,7 @@ module Puppet
         String(value)
       end
     end
-    
+
     newparam(:repo_name) do
       desc 'The repository name the deploy key will be associated. If this parameter is ommitted, the deploy key will be associated with the project instead. Optional.  NOTE: Stash only.'
       munge do |value|

--- a/lib/puppet/type/git_deploy_key.rb
+++ b/lib/puppet/type/git_deploy_key.rb
@@ -1,5 +1,8 @@
+require 'puppet_x/gms/type'
+
 module Puppet
   Puppet::Type.newtype(:git_deploy_key) do
+    include PuppetX::GMS::Type
 
     @doc = %q{A deploy key is an SSH key that is stored on your server and grants access to a single GitHub repository.  This key is attached directly to the repository instead of to a personal user account.  Anyone with access to the repository and server has the ability to deploy the project.  It is also beneficial for users since they are not required to change their local SSH settings.
     }
@@ -22,26 +25,10 @@ module Puppet
       end
     end
 
-    newparam(:token) do
-      desc 'The private token require to manipulate the Git management system provider chosen.'
-      munge do |value|
-        String(value)
-      end
-    end
-
-    newparam(:username) do
-      desc 'The username to be used to authenticate with the Stash server for API access.'
-      munge do |value|
-        String(value)
-      end
-    end
-
-    newparam(:password) do
-      desc 'The password to be used to authenticate with the Stash server for API access.'
-      munge do |value|
-        String(value)
-      end
-    end
+    add_parameter_token
+    add_parameter_token_file
+    add_parameter_username
+    add_parameter_password
 
     newparam(:project_id) do
       desc 'The project ID associated with the project.'
@@ -76,6 +63,10 @@ module Puppet
 
     autorequire(:file) do
       self[:path]if self[:path] and Pathname.new(self[:path]).absolute?
+    end
+
+    validate do
+      validate_token_or_token_file
     end
 
   end

--- a/lib/puppet/type/git_groupteam.rb
+++ b/lib/puppet/type/git_groupteam.rb
@@ -1,7 +1,7 @@
 require 'puppet/parameter/boolean'
 
 module Puppet
-  Puppet::Type.newtype(:git_groupteam) do 
+  Puppet::Type.newtype(:git_groupteam) do
 
     @doc = %q{TODO
     }
@@ -21,7 +21,7 @@ module Puppet
         String(value)
       end
     end
-    
+
     # newparam(:username) do
     #   desc 'The username to be used for authentication vs a token. Required. NOTE: Stash only.'
     #   munge do |value|
@@ -49,21 +49,21 @@ module Puppet
     #     String(value)
     #   end
     # end
-    
+
     newparam(:description) do
       desc 'The description associated with the group to be managed. Optional.'
       munge do |value|
         String(value)
       end
     end
-    
+
     # newparam(:repo_name) do
     #   desc 'The name of the repository associated with the webhook. Required. NOTE: Stash only.'
     #   munge do |value|
     #     String(value)
     #   end
     # end
-    
+
     # newparam(:hook_exe) do
     #   desc 'The absolute path to the exectuable triggered when a commit has been made to the respository. Required. NOTE: Stash only.'
     #   munge do |value|
@@ -77,7 +77,7 @@ module Puppet
     #     String(value)
     #   end
     # end
-    
+
     # newparam(:merge_request_events, :boolean => true, :parent => Puppet::Parameter::Boolean) do
     #   desc 'The URL in the webhook_url parameter will be triggered when a merge request is created. Optional. NOTE: GitLab only'
     #

--- a/lib/puppet/type/git_groupteam.rb
+++ b/lib/puppet/type/git_groupteam.rb
@@ -1,7 +1,9 @@
 require 'puppet/parameter/boolean'
+require 'puppet_x/gms/type'
 
 module Puppet
   Puppet::Type.newtype(:git_groupteam) do
+    include PuppetX::GMS::Type
 
     @doc = %q{TODO
     }
@@ -15,26 +17,11 @@ module Puppet
       desc 'A unique title for the key that will be provided to the prefered Git management system. Required.'
     end
 
-    newparam(:token) do
-      desc 'The private token require to manipulate the Git management system provider chosen. Required. NOTE: GitHub & GitLab only.'
-      munge do |value|
-        String(value)
-      end
-    end
+    add_parameter_token
+    add_parameter_token_file
 
-    # newparam(:username) do
-    #   desc 'The username to be used for authentication vs a token. Required. NOTE: Stash only.'
-    #   munge do |value|
-    #     String(value)
-    #   end
-    # end
-    #
-    # newparam(:password) do
-    #   desc 'The password to be used for authentication vs a token. Required. Note: Stash only.'
-    #   munge do |value|
-    #     String(value)
-    #   end
-    # end
+    # add_parameter_username
+    # add_parameter_password
 
     # newparam(:project_id) do
     #   desc 'The project ID associated with the project.'
@@ -110,6 +97,10 @@ module Puppet
           raise(Puppet::Error, "Git server URL must be fully qualified, not '#{value}'")
         end
       end
+    end
+
+    validate do
+      validate_token_or_token_file
     end
 
   end

--- a/lib/puppet/type/git_groupteam_member.rb
+++ b/lib/puppet/type/git_groupteam_member.rb
@@ -1,7 +1,9 @@
 require 'puppet/parameter/boolean'
+require 'puppet_x/gms/type'
 
 module Puppet
   Puppet::Type.newtype(:git_groupteam_member) do
+    include PuppetX::GMS::Type
 
     @doc = %q{TODO
     }
@@ -15,26 +17,11 @@ module Puppet
       desc 'A unique title for the key that will be provided to the prefered Git management system. Required.'
     end
 
-    newparam(:token) do
-      desc 'The private token require to manipulate the Git management system provider chosen. Required. NOTE: GitHub & GitLab only.'
-      munge do |value|
-        String(value)
-      end
-    end
+    add_parameter_token
+    add_parameter_token_file
 
-    # newparam(:username) do
-    #   desc 'The username to be used for authentication vs a token. Required. NOTE: Stash only.'
-    #   munge do |value|
-    #     String(value)
-    #   end
-    # end
-    #
-    # newparam(:password) do
-    #   desc 'The password to be used for authentication vs a token. Required. Note: Stash only.'
-    #   munge do |value|
-    #     String(value)
-    #   end
-    # end
+    # add_parameter_username
+    # add_parameter_password
 
     # newparam(:project_id) do
     #   desc 'The project ID associated with the project.'
@@ -117,6 +104,10 @@ module Puppet
           raise(Puppet::Error, "Git server URL must be fully qualified, not '#{value}'")
         end
       end
+    end
+
+    validate do
+      validate_token_or_token_file
     end
 
   end

--- a/lib/puppet/type/git_groupteam_member.rb
+++ b/lib/puppet/type/git_groupteam_member.rb
@@ -1,7 +1,7 @@
 require 'puppet/parameter/boolean'
 
 module Puppet
-  Puppet::Type.newtype(:git_groupteam_member) do 
+  Puppet::Type.newtype(:git_groupteam_member) do
 
     @doc = %q{TODO
     }
@@ -21,7 +21,7 @@ module Puppet
         String(value)
       end
     end
-    
+
     # newparam(:username) do
     #   desc 'The username to be used for authentication vs a token. Required. NOTE: Stash only.'
     #   munge do |value|
@@ -49,28 +49,28 @@ module Puppet
     #     String(value)
     #   end
     # end
-    
+
     newparam(:member_name) do
       desc 'The member name to be managed in regards to the group/team. Required.'
       munge do |value|
         String(value)
       end
     end
-    
+
     newparam(:access_level) do
       desc 'The access level associated with member being managed in regards to group/team. Required.'
       munge do |value|
         String(value)
       end
     end
-    
+
     # newparam(:repo_name) do
     #   desc 'The name of the repository associated with the webhook. Required. NOTE: Stash only.'
     #   munge do |value|
     #     String(value)
     #   end
     # end
-    
+
     # newparam(:hook_exe) do
     #   desc 'The absolute path to the exectuable triggered when a commit has been made to the respository. Required. NOTE: Stash only.'
     #   munge do |value|
@@ -84,7 +84,7 @@ module Puppet
     #     String(value)
     #   end
     # end
-    
+
     # newparam(:merge_request_events, :boolean => true, :parent => Puppet::Parameter::Boolean) do
     #   desc 'The URL in the webhook_url parameter will be triggered when a merge request is created. Optional. NOTE: GitLab only'
     #

--- a/lib/puppet/type/git_webhook.rb
+++ b/lib/puppet/type/git_webhook.rb
@@ -1,7 +1,9 @@
 require 'puppet/parameter/boolean'
+require 'puppet_x/gms/type'
 
 module Puppet
   Puppet::Type.newtype(:git_webhook) do
+    include PuppetX::GMS::Type
 
     @doc = %q{TODO
     }
@@ -24,26 +26,10 @@ module Puppet
       end
     end
 
-    newparam(:token) do
-      desc 'The private token require to manipulate the Git management system provider chosen. Required. NOTE: GitHub & GitLab only.'
-      munge do |value|
-        String(value)
-      end
-    end
-
-    newparam(:username) do
-      desc 'The username to be used for authentication vs a token. Required. NOTE: Stash only.'
-      munge do |value|
-        String(value)
-      end
-    end
-
-    newparam(:password) do
-      desc 'The password to be used for authentication vs a token. Required. Note: Stash only.'
-      munge do |value|
-        String(value)
-      end
-    end
+    add_parameter_token
+    add_parameter_token_file
+    add_parameter_username
+    add_parameter_password
 
     newparam(:project_id) do
       desc 'The project ID associated with the project.'
@@ -112,6 +98,10 @@ module Puppet
           raise(Puppet::Error, "Git server URL must be fully qualified, not '#{value}'")
         end
       end
+    end
+
+    validate do
+      validate_token_or_token_file
     end
 
   end

--- a/lib/puppet/type/git_webhook.rb
+++ b/lib/puppet/type/git_webhook.rb
@@ -1,7 +1,7 @@
 require 'puppet/parameter/boolean'
 
 module Puppet
-  Puppet::Type.newtype(:git_webhook) do 
+  Puppet::Type.newtype(:git_webhook) do
 
     @doc = %q{TODO
     }
@@ -30,14 +30,14 @@ module Puppet
         String(value)
       end
     end
-    
+
     newparam(:username) do
       desc 'The username to be used for authentication vs a token. Required. NOTE: Stash only.'
       munge do |value|
         String(value)
       end
     end
-    
+
     newparam(:password) do
       desc 'The password to be used for authentication vs a token. Required. Note: Stash only.'
       munge do |value|
@@ -58,14 +58,14 @@ module Puppet
         String(value)
       end
     end
-    
+
     newparam(:repo_name) do
       desc 'The name of the repository associated with the webhook. Required. NOTE: Stash only.'
       munge do |value|
         String(value)
       end
     end
-    
+
     newparam(:hook_exe) do
       desc 'The absolute path to the exectuable triggered when a commit has been made to the respository. Required. NOTE: Stash only.'
       munge do |value|
@@ -79,28 +79,28 @@ module Puppet
         String(value)
       end
     end
-    
+
     newparam(:merge_request_events, :boolean => true, :parent => Puppet::Parameter::Boolean) do
       desc 'The URL in the webhook_url parameter will be triggered when a merge request is created. Optional. NOTE: GitLab only'
-     
+
       defaultto false
     end
-    
+
     newparam(:tag_push_events, :boolean => true, :parent => Puppet::Parameter::Boolean) do
       desc 'The URL in the webhook_url parameter will be triggered when a tag push event occurs. Optional. NOTE: GitLab only'
-      
+
       defaultto false
     end
-    
+
     newparam(:issue_events, :boolean => true, :parent => Puppet::Parameter::Boolean) do
       desc 'The URL in the webhook_url parameter will be triggered when an issue event occurs. Optional. NOTE: GitLab only.'
-      
+
       defaultto false
-    end 
-    
+    end
+
     newparam(:disable_ssl_verify, :boolean => true, :parent => Puppet::Parameter::Boolean) do
       desc 'Boolean value for disabling SSL verification for this webhook. Optional. NOTE: GitHub only'
-      
+
       defaultto false
     end
 

--- a/lib/puppet_x/gms/provider.rb
+++ b/lib/puppet_x/gms/provider.rb
@@ -1,0 +1,15 @@
+# Forward declaration(s)
+module PuppetX; end
+module PuppetX::GMS; end
+
+module PuppetX::GMS::Provider
+  def get_token
+    @token ||= if resource[:token]
+      resource[:token].strip
+    elsif resource[:token_file]
+      File.read(resource[:token_file]).strip
+    else
+      raise(Puppet::Error, "github_webhook::#{calling_method}: Must provide at least one of the following attributes: token or token_file")
+    end
+  end
+end

--- a/lib/puppet_x/gms/type.rb
+++ b/lib/puppet_x/gms/type.rb
@@ -1,0 +1,55 @@
+# Forward declaration(s)
+module PuppetX; end
+module PuppetX::GMS; end
+
+module PuppetX::GMS::Type
+  def validate_token_or_token_file
+    # The token and token_file parameters are mutually exclusive. It is an
+    # error to provide both simultaneously.
+    if !parameters[:token].nil? and !parameters[:token_file].nil?
+      fail 'token and token_file are mutually exclusive. Only one of these parameters can be specified, not both together'
+    end
+  end
+
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
+  module ClassMethods
+    def add_parameter_token
+      newparam(:token) do
+        desc 'The private token require to manipulate the Git management system provider chosen.'
+        munge do |value|
+          String(value)
+        end
+      end
+    end
+
+    def add_parameter_token_file
+      newparam(:token_file) do
+        desc 'The path to a file on the agent containing the private token require to manipulate the Git management system provider chosen. Required. NOTE: GitHub & GitLab only.'
+        munge do |value|
+          String(value)
+        end
+      end
+    end
+
+    def add_parameter_username
+      newparam(:username) do
+        desc 'The username to be used to authenticate with the Stash server for API access.'
+        munge do |value|
+          String(value)
+        end
+      end
+    end
+
+    def add_parameter_password
+      newparam(:password) do
+        desc 'The password to be used to authenticate with the Stash server for API access.'
+        munge do |value|
+          String(value)
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet_x/puppetlabs/gms.rb
+++ b/lib/puppet_x/puppetlabs/gms.rb
@@ -139,6 +139,8 @@ module PuppetX
           req.set_content_type('application/json')
           if @token && ! @token.empty?
             req.add_field('Authorization', "token #{@token}")
+          elsif @token_file && ! @token_file.empty? && File.exist?(@token_file)
+            req.add_field('Authorization', "token #{File.read(@token_file).strip}")
           elsif ENV['GMS_TOKEN']
             req.add_field('Authorization', "token #{ENV['GMS_TOKEN'].strip}")
           else


### PR DESCRIPTION
The token_file parameter can be used in place of the token parameter for applicable types. This allows for the provider to function without the token value being known to the master, or being known during catalog compilation.

To avoid code duplication, this was implemented with a mixin.

The purpose of this is to allow the types/providers to be used in circumstances where the api token is unknown to Puppet (not in Hiera, not in a fact) but is or will be available at the time of catalog application in a file.